### PR TITLE
Ad/feature/ingredient class

### DIFF
--- a/src/recipe.js
+++ b/src/recipe.js
@@ -13,9 +13,9 @@ class Recipe {
   }
 
   instantiateIngredients(recipe, ingredientsData) {
-    return recipe.ingredients.map(ing => {
-      const ingredientInfo = ingredientsData.find(i => i.id === ing.id);
-      return new Ingredient(ingredientInfo, ing);
+    return recipe.ingredients.map(recipeIngredient => {
+      const ingredientInfo = ingredientsData.find(ingredient => ingredient.id === recipeIngredient.id);
+      return new Ingredient(ingredientInfo, recipeIngredient);
     });
   }
   

--- a/test/ingredient-test.js
+++ b/test/ingredient-test.js
@@ -1,21 +1,22 @@
 import { expect } from 'chai';
 
+import recipesData from '../src/data/recipe-data';
+import Recipe from '../src/recipe';
 import Ingredient from '../src/ingredient';
-import ingredientsData from '../src/data/ingredient-data';
 
 describe.only('Ingredient', () => {
+  let recipe;
   let ingredient1;
   let ingredient2;
   let ingredient3;
   let ingredient4;
-  let allingredients;
 
   beforeEach(() => {
-    ingredient1 = new Ingredient(ingredientsData[0], ingredientsData);
-    ingredient2 = new Ingredient(ingredientsData[1], ingredientsData);
-    ingredient3 = new Ingredient(ingredientsData[2], ingredientsData);
-    ingredient4 = new Ingredient(ingredientsData[3], ingredientsData);
-    allingredients = [ingredient1, ingredient2, ingredient3, ingredient4];
+    recipe = new Recipe(recipesData[0]);
+    ingredient1 = recipe.ingredients[0];
+    ingredient2 = recipe.ingredients[1];
+    ingredient3 = recipe.ingredients[2];
+    ingredient4 = recipe.ingredients[3];
   });
 
   it('should be a function', () => {
@@ -23,19 +24,26 @@ describe.only('Ingredient', () => {
   });
 
   it('should be an instance of Ingredient', () => {
-    expect(allingredients[0]).to.be.an.instanceof(Ingredient);
+
+    console.log('ingredient1 >>>>>>>>', ingredient1);
+
+    expect(ingredient1).to.be.an.instanceof(Ingredient);
   });
 
   it('should initialize with an id number', () => {
-    expect(allingredients[1].id).to.equal(18372);
+    expect(ingredient2.id).to.equal(18372);
   });
 
   it('should initialize with an name', () => {
-    expect(allingredients[2].name).to.equal('Dirty Steve\'s Original Wing Sauce');
+    expect(ingredient3.name).to.equal('egg');
   });
 
   it('should initialize with an estimated amount the ingredient costs', () => {
-    expect(allingredients[1].estimatedCostInCents).to.equal(582);
+    expect(ingredient4.estimatedCostInCents).to.equal(902);
+  });
+
+  it('should initialize with a quantity needed for the relevant recipe', () => {
+    expect(ingredient1.quantity).to.deep.equal({ amount: 1.5, unit: 'c' });
   });
 
 });

--- a/test/recipe-test.js
+++ b/test/recipe-test.js
@@ -104,7 +104,6 @@ describe.only('Recipe', () => {
 
   it('should return the instructions to cook the recipe', () => {
     let recipeInstructions = allRecipes[2].getInstructions();
-    console.log(allRecipes[2])
     expect(recipeInstructions).to.deep.equal([
       {
         "number": 1,


### PR DESCRIPTION
**Changes:**

> Incorporates ingredient-test file for Ingredient class.
instances of the Ingredient class are relative to a specific recipe (instantiated to set the value of the `ingredients` property when a new Recipe is instantiated)
> Also updates variable names where Ingredients are instantiated within the Recipe class.

**Issues:**
> #23 

- [x] DRY and SRP
- [x] Tested Locally

**Where should the reviewer start?**
Line 16 in recipe.js
Line 3 in ingredient-test.js

**Notes:**
> The Ingredient class itself has no methods, but is being used to combine relevant ingredient properties.
The ingredients appear to be instantiated correctly - included all properties being set to expected values - and prints recognizing an instance of the Ingredient class, yet still failed the unit test specifically checking that it is an instance of the class.
