### PR TITLE
Add helper and calls for favs and toCook clicks

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -153,10 +153,10 @@ function mainClicks(event) {
       target.closest('.recipe-card').classList.add('recipe-card-active')
       break;
     case 'icon-fav' || 'icon-fav-text':
-      saveToFavorites(targetRecipe)
+      addOrRemoveFromUserList(targetRecipe, 'isFavorited', 'favoriteRecipes')
       break;
     case 'icon-cook' || 'icon-cook-text':
-      addToCookList(targetRecipe)
+      addOrRemoveFromUserList(targetRecipe, 'isToCook', 'recipesToCook')
       break;
     case 'exit-recipe':
       target.closest('.recipe-card').classList.remove('recipe-card-active')
@@ -180,20 +180,14 @@ function findTargetRecipe(target) {
   return recipes.find(recipe => recipe.id == targetId)
 }
 
-function saveToFavorites(targetRecipe) {
-  if (targetRecipe.isFavorited) {
-    targetRecipe.isFavorited = false
-    user.removeRecipe(targetRecipe, 'favoriteRecipes')
+function addOrRemoveFromUserList(targetRecipe, checkProperty, userListName) {
+  if (targetRecipe[checkProperty]) {
+    targetRecipe[checkProperty] = false
+    user.removeRecipe(targetRecipe, userListName)
   } else {
-    targetRecipe.isFavorited = true
-  user.saveRecipe(targetRecipe, 'favoriteRecipes')
+    targetRecipe[checkProperty] = true
+    user.saveRecipe(targetRecipe, userListName)
   }
-  showHome()
-}
-
-function addToCookList(targetRecipe) {
-  targetRecipe.isToCook = true
-  user.saveRecipe(targetRecipe, 'recipesToCook')
   showHome()
 }
 


### PR DESCRIPTION
**Changes:**
- Add helper function to addOrRemoveFromList
  - this takes a target recipe and toggles the property denoting it's in a list
  - it also removes it from a certain user's list
- Make sure you can delete from the 'Add to Cook' list

**Issues:**
- Maybe change the name for the 'add to cook' icon since it can delete now

- [x] DRY and SRP
- [x] Tested Locally

**Where should the reviewer start?**
- Lines 156, 159, and 183 of scripts

**Notes:**
- should be dry!

